### PR TITLE
Make channel speed optional in schema

### DIFF
--- a/Docs/Parameters XML File/ARINC429_Parameters_XML_Schema.xsd
+++ b/Docs/Parameters XML File/ARINC429_Parameters_XML_Schema.xsd
@@ -26,7 +26,7 @@
                            </xs:restriction>
                         </xs:simpleType>
                      </xs:element>
-                     <xs:element name="speed"  maxOccurs="1" minOccurs="1">
+                     <xs:element name="speed" default="high" maxOccurs="1" minOccurs="0">
                         <xs:annotation>
                            <xs:documentation>For ARINC 429, high speed is 100kHz, low speed is 12.5kHz.</xs:documentation>
                         </xs:annotation>

--- a/Docs/Parameters XML File/Parameters XML File.md
+++ b/Docs/Parameters XML File/Parameters XML File.md
@@ -107,7 +107,7 @@ The following table describes the XML elements, or tags, you can use in a Parame
 |`<channel>`|Yes|complex|1/16|Opening tag for a channel labels definition.|
 |→`<hardwareChannel>`|Yes|xs:int|1|Specifies the Hardware Channel used. Range is: [0:31].|
 |→`<direction>`|Yes|xs:string|1|Specifies whether the channel is incoming (Rx) or outgoing (Tx).|
-|→`<speed>`|Yes|xs:string|1|Specifies the transfer rate of the channel. Supported values:<br/>low - 12.5 kHz<br/>high - 100 kHz|
+|→`<speed>`|No|xs:string|0/1|Specifies the transfer rate of the channel. Supported values:<br/>low - 12.5 kHz<br/>high - 100 kHz (default)|
 |→`<label>`|Yes|complex|1/256|Opening tag for a label definition..|
 |→→`<labelDecimal>`|No<sup>1</sup>|xs:int|0/1|Specifies the label (decimal). Range is: [0:255].|
 |→→`<labelOctal>`|No<sup>1</sup>|xs:int|0/1|Specifies the label (octal). Range is: [0:377].|


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-aim-arinc429-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Annotates that channel speed is optional when using the parameters XML and the default is "high".
Addresses [AB#1917418](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1917418)

### Why should this Pull Request be merged?

There is already a default for channel speed in our implementation. Use that instead of requiring it in the XML.

### What testing has been done?

N/A
