### PR TITLE
added explicit closing tag for xs:emelent to enable xsd class generation

### DIFF
--- a/Docs/Parameters XML File/ARINC429_Parameters_XML_Schema.xsd
+++ b/Docs/Parameters XML File/ARINC429_Parameters_XML_Schema.xsd
@@ -84,22 +84,26 @@
                                     <xs:documentation>Period (in microseconds) at which scheduled Tx labels are continuously transmitted. This tag is ignored for Rx labels.</xs:documentation>
                                  </xs:annotation>
                               </xs:element>
-                              <xs:element type="xs:boolean" name="createTimestampChannel" maxOccurs="1" minOccurs="0" default="false"/>
+                              <xs:element type="xs:boolean" name="createTimestampChannel" maxOccurs="1" minOccurs="0" default="false">
                                  <xs:annotation>
                                     <xs:documentation>Automatic creation of read-only VeriStand channel for timestamp is only supported for Rx labels. This tag is ignored for Tx labels.</xs:documentation>
                                  </xs:annotation>
-                              <xs:element type="xs:boolean" name="createSDIChannel" maxOccurs="1" minOccurs="0" default="false"/>
+								</xs:element>
+                              <xs:element type="xs:boolean" name="createSDIChannel" maxOccurs="1" minOccurs="0" default="false">
                                  <xs:annotation>
                                     <xs:documentation>Automatic creation of read-only VeriStand channel for SDI is only supported for Rx labels. This tag is ignored for Tx labels.</xs:documentation>
                                  </xs:annotation>
-                              <xs:element type="xs:boolean" name="createSSMChannel" maxOccurs="1" minOccurs="0" default="false"/>
+							</xs:element>
+                              <xs:element type="xs:boolean" name="createSSMChannel" maxOccurs="1" minOccurs="0" default="false">
                                  <xs:annotation>
                                     <xs:documentation>Automatic creation of read-only VeriStand channel for SSM is only supported for Rx labels. This tag is ignored for Tx labels.</xs:documentation>
                                  </xs:annotation>
-                              <xs:element type="xs:boolean" name="createParityChannel" maxOccurs="1" minOccurs="0" default="false"/>
+							</xs:element>
+                              <xs:element type="xs:boolean" name="createParityChannel" maxOccurs="1" minOccurs="0" default="false">
                                  <xs:annotation>
                                     <xs:documentation>Automatic creation of read-only VeriStand channel for Parity is only supported for Rx labels. This tag is ignored for Tx labels.</xs:documentation>
                                  </xs:annotation>
+							</xs:element>
                               <xs:element name="parameter" maxOccurs="unbounded" minOccurs="1">
                                  <xs:complexType>
                                     <xs:choice maxOccurs="unbounded" minOccurs="0">


### PR DESCRIPTION
- [x ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-aim-arinc429-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
minor change to the parameter xsd schema to enable xsd.exe utility to generate C# classes for serialization/deserialization of XML files. 

