### PR TITLE
added explicing tag closing and schema elements and set parameter data type to sequence

### DIFF
--- a/Docs/Parameters XML File/ARINC429_Parameters_XML_Schema.xsd
+++ b/Docs/Parameters XML File/ARINC429_Parameters_XML_Schema.xsd
@@ -106,7 +106,7 @@
 							</xs:element>
                               <xs:element name="parameter" maxOccurs="unbounded" minOccurs="1">
                                  <xs:complexType>
-                                    <xs:choice maxOccurs="unbounded" minOccurs="0">
+                                    <xs:sequence>
                                        <xs:element name="encoding" default="BNR" maxOccurs="1" minOccurs="1">
                                           <xs:simpleType>
                                              <xs:restriction base="xs:string">
@@ -142,7 +142,7 @@
                                        </xs:element>
                                        <xs:element type="xs:string" name="unit" maxOccurs="1" minOccurs="0"/>
                                        <xs:element type="xs:double" name="defaultValue"  default="0.0"/>
-                                    </xs:choice>
+                                    </xs:sequence>
                                  </xs:complexType>
                               </xs:element>
                            </xs:sequence>

--- a/Docs/Parameters XML File/ARINC429_Parameters_XML_Schema.xsd
+++ b/Docs/Parameters XML File/ARINC429_Parameters_XML_Schema.xsd
@@ -84,22 +84,26 @@
                                     <xs:documentation>Period (in microseconds) at which scheduled Tx labels are continuously transmitted. This tag is ignored for Rx labels.</xs:documentation>
                                  </xs:annotation>
                               </xs:element>
-                              <xs:element type="xs:boolean" name="createTimestampChannel" maxOccurs="1" minOccurs="0" default="false"/>
+                              <xs:element type="xs:boolean" name="createTimestampChannel" maxOccurs="1" minOccurs="0" default="false">
                                  <xs:annotation>
                                     <xs:documentation>Automatic creation of read-only VeriStand channel for timestamp is only supported for Rx labels. This tag is ignored for Tx labels.</xs:documentation>
                                  </xs:annotation>
-                              <xs:element type="xs:boolean" name="createSDIChannel" maxOccurs="1" minOccurs="0" default="false"/>
+								</xs:element>
+                              <xs:element type="xs:boolean" name="createSDIChannel" maxOccurs="1" minOccurs="0" default="false">
                                  <xs:annotation>
                                     <xs:documentation>Automatic creation of read-only VeriStand channel for SDI is only supported for Rx labels. This tag is ignored for Tx labels.</xs:documentation>
                                  </xs:annotation>
-                              <xs:element type="xs:boolean" name="createSSMChannel" maxOccurs="1" minOccurs="0" default="false"/>
+							</xs:element>
+                              <xs:element type="xs:boolean" name="createSSMChannel" maxOccurs="1" minOccurs="0" default="false">
                                  <xs:annotation>
                                     <xs:documentation>Automatic creation of read-only VeriStand channel for SSM is only supported for Rx labels. This tag is ignored for Tx labels.</xs:documentation>
                                  </xs:annotation>
-                              <xs:element type="xs:boolean" name="createParityChannel" maxOccurs="1" minOccurs="0" default="false"/>
+							</xs:element>
+                              <xs:element type="xs:boolean" name="createParityChannel" maxOccurs="1" minOccurs="0" default="false">
                                  <xs:annotation>
                                     <xs:documentation>Automatic creation of read-only VeriStand channel for Parity is only supported for Rx labels. This tag is ignored for Tx labels.</xs:documentation>
                                  </xs:annotation>
+							</xs:element>
                               <xs:element name="parameter" maxOccurs="unbounded" minOccurs="1">
                                  <xs:complexType>
                                     <xs:choice maxOccurs="unbounded" minOccurs="0">


### PR DESCRIPTION
- [x ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-aim-arinc429-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
added a couple of edits to the .xsd schema file to enable XSD utility to generate C# classes and .NET assembly to script parameter XML / sysdef from text / configuration editor (e.g. Excel file)

### Why should this Pull Request be merged?
It's a minor change to the xsd schema that does not affect its structure and Custom device operation

### What testing has been done?

tested XML created using C# serialization with AIM custom device