### PR TITLE
Revert "fix: enabled some settings". Just keep add lv2025, remove lv2021, bump version. Disable remove block diagram

### DIFF
--- a/Source/Custom Device/AIM ARINC 429 Custom Device.lvproj
+++ b/Source/Custom Device/AIM ARINC 429 Custom Device.lvproj
@@ -1,5 +1,5 @@
 ﻿<?xml version='1.0' encoding='UTF-8'?>
-<Project Type="Project" LVVersion="21008000">
+<Project Type="Project" LVVersion="20008000">
 	<Property Name="CCSymbols" Type="Str"></Property>
 	<Property Name="NI.LV.All.SourceOnly" Type="Bool">true</Property>
 	<Property Name="NI.Project.Description" Type="Str"></Property>
@@ -408,26 +408,15 @@
 				<Item Name="Waveform Subtype Enum__ogtk__jki_vi_tester.ctl" Type="VI" URL="/&lt;vilib&gt;/addons/_JKI Toolkits/VI Tester/_support/Support.llb/Waveform Subtype Enum__ogtk__jki_vi_tester.ctl"/>
 				<Item Name="whitespace.ctl" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/whitespace.ctl"/>
 			</Item>
-			<Item Name="ActionVIOnLoad.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/Dynamically Called/ActionVIOnLoad.vi"/>
-			<Item Name="Add Timing Channels RTM.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/Add Timing Channels RTM.vi"/>
-			<Item Name="Asynchronous Execution Unit Compiled Information.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Engine/Custom Device/Asynchronous Execution Unit Compiled Information.ctl"/>
-			<Item Name="Block Data Reference.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Block Data Reference.ctl"/>
-			<Item Name="Can Add Timing Channels.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/Can Add Timing Channels.vi"/>
-			<Item Name="Check if Custom Device is Enabled.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/Check if Custom Device is Enabled.vi"/>
-			<Item Name="Compiled.Settings.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Engine/Custom Device/Compiled.Settings.ctl"/>
-			<Item Name="Custom Device Item Ref.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Custom Device Item Ref.ctl"/>
-			<Item Name="Custom Device Item Ref.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 System Explorer.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Custom Device Item Ref.ctl"/>
-			<Item Name="Custom Device RTM Dependency.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 System Explorer.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Custom Device RTM Dependency.ctl"/>
-			<Item Name="Data Reference.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Data Reference.ctl"/>
-			<Item Name="EnableDisable RTM.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/EnableDisable RTM.vi"/>
-			<Item Name="Execution Unit Factory.lvclass" Type="LVClass" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Engine/Implementation/Execution Unit Factory/Execution Unit Factory.lvclass"/>
-			<Item Name="Execution Unit Factory.lvclass" Type="LVClass" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Engine/Interfaces/Execution Unit Factory/Execution Unit Factory.lvclass"/>
-			<Item Name="Execution Unit Information.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Engine/Interfaces/Controls/Execution Unit Information.ctl"/>
-			<Item Name="Execution Unit.lvclass" Type="LVClass" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Engine/Interfaces/Execution Unit/Execution Unit.lvclass"/>
-			<Item Name="Export Configuration RTM.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/Export Configuration RTM.vi"/>
-			<Item Name="Import Configuration RTM.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/Import Configuration RTM.vi"/>
-			<Item Name="Initialize.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/Dynamically Called/Initialize.vi"/>
-			<Item Name="Inline Execution Unit Compiled Information.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Engine/Custom Device/Inline Execution Unit Compiled Information.ctl"/>
+			<Item Name="DOMUserDefRef.dll" Type="Document" URL="DOMUserDefRef.dll">
+				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
+			</Item>
+			<Item Name="mscorlib" Type="VI" URL="mscorlib">
+				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
+			</Item>
+			<Item Name="NationalInstruments.VeriStand.Internal" Type="Document" URL="NationalInstruments.VeriStand.Internal">
+				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
+			</Item>
 			<Item Name="NationalInstruments.VeriStand.SystemDefinitionAPI" Type="Document" URL="NationalInstruments.VeriStand.SystemDefinitionAPI">
 				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
 			</Item>
@@ -437,12 +426,10 @@
 			<Item Name="NationalInstruments.VeriStand.XMLReader" Type="Document" URL="NationalInstruments.VeriStand.XMLReader">
 				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
 			</Item>
-			<Item Name="RT Driver VI.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Engine/Custom Device/RT Driver VI.vi"/>
-			<Item Name="Shared Resources Factory.lvclass" Type="LVClass" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Engine/Implementation/Shared Resources Factory/Shared Resources Factory.lvclass"/>
-			<Item Name="Shared Resources Factory.lvclass" Type="LVClass" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Engine/Interfaces/Shared Resources Factory/Shared Resources Factory.lvclass"/>
-			<Item Name="Shared Resources.lvclass" Type="LVClass" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Engine/Interfaces/Shared Resources/Shared Resources.lvclass"/>
-			<Item Name="System Explorer Dispatcher.lvclass" Type="LVClass" URL="../../../Includes/AIM ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer Dispatcher/System Explorer Dispatcher.lvclass"/>
-			<Item Name="System Explorer Dispatcher.lvclass" Type="LVClass" URL="../../../Includes/AIM ARINC 429 System Explorer.lvlibp/System Explorer/Interfaces/System Explorer Dispatcher/System Explorer Dispatcher.lvclass"/>
+			<Item Name="NIVeriStand_DataServices.dll" Type="Document" URL="../../../Includes/NIVeriStand_DataServices.dll"/>
+			<Item Name="systemLogging.dll" Type="Document" URL="systemLogging.dll">
+				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
+			</Item>
 		</Item>
 		<Item Name="Build Specifications" Type="Build">
 			<Property Name="NI.SortType" Type="Int">3</Property>
@@ -771,10 +758,84 @@
 				<Item Name="Trim Whitespace.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/Trim Whitespace.vi"/>
 				<Item Name="whitespace.ctl" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/whitespace.ctl"/>
 			</Item>
+			<Item Name="AIM ARINC 429 Engine.lvlibp" Type="LVLibp" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp">
+				<Item Name="AIM ARINC 429 Hardware API.lvlib" Type="Library" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Hardware API/AIM ARINC 429 Hardware API.lvlib"/>
+				<Item Name="AIM ARINC 429 Scripting.lvlib" Type="Library" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Scripting/AIM/AIM ARINC 429 Scripting.lvlib"/>
+				<Item Name="AIM ARINC 429 System Explorer.lvlib" Type="Library" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/System Explorer/Implementation/System Explorer/AIM ARINC 429 System Explorer.lvlib"/>
+				<Item Name="AIM429LV.lvlib" Type="Library" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/instr.lib/AIM GmbH/_ARINC-429/AIM429LV.lvlib"/>
+				<Item Name="Build Linux Log File Path.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Shared/Build Linux Log File Path.vi"/>
+				<Item Name="BuildHelpPath.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/BuildHelpPath.vi"/>
+				<Item Name="Check Special Tags.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Check Special Tags.vi"/>
+				<Item Name="Clear Errors.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Clear Errors.vi"/>
+				<Item Name="Convert property node font to graphics font.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Convert property node font to graphics font.vi"/>
+				<Item Name="Create Directory Recursive.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/libraryn.llb/Create Directory Recursive.vi"/>
+				<Item Name="Create NI GUID.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/string/Create NI GUID.vi"/>
+				<Item Name="Custom Device API.lvlib" Type="Library" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Custom Device API.lvlib"/>
+				<Item Name="Custom Device Utility Library.lvlib" Type="Library" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device Tools/Custom Device Utility Library/Custom Device Utility Library.lvlib"/>
+				<Item Name="Custom Device.lvlib" Type="Library" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Engine/Custom Device/Custom Device.lvlib"/>
+				<Item Name="Data Access Engine.lvlib" Type="Library" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI/NIVS Inline Async API/_Data Access Engine/Data Access Engine.lvlib"/>
+				<Item Name="Data Word Format.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Shared/Data Word Format.ctl"/>
+				<Item Name="Decode Parameter (DBL) from Word.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Shared/Decode Parameter (DBL) from Word.vi"/>
+				<Item Name="Details Display Dialog.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Details Display Dialog.vi"/>
+				<Item Name="Device Parameters.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Shared/Device Parameters.ctl"/>
+				<Item Name="DialogType.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/DialogType.ctl"/>
+				<Item Name="DialogTypeEnum.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/DialogTypeEnum.ctl"/>
+				<Item Name="Encode Parameter and Update Word (32-bit).vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Shared/Encode Parameter and Update Word (32-bit).vi"/>
+				<Item Name="Encoding and Decoding.lvlib" Type="Library" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI/NI VeriStand Encoding and Decoding/Encoding and Decoding.lvlib"/>
+				<Item Name="Error Cluster From Error Code.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Error Cluster From Error Code.vi"/>
+				<Item Name="Error Code Database.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Error Code Database.vi"/>
+				<Item Name="ErrWarn.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/ErrWarn.ctl"/>
+				<Item Name="eventvkey.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/event_ctls.llb/eventvkey.ctl"/>
+				<Item Name="Find Tag.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Find Tag.vi"/>
+				<Item Name="Format Message String.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Format Message String.vi"/>
+				<Item Name="General Error Handler Core CORE.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/General Error Handler Core CORE.vi"/>
+				<Item Name="General Error Handler.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/General Error Handler.vi"/>
+				<Item Name="Get Label Settings for RT.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Shared/Get Label Settings for RT.vi"/>
+				<Item Name="Get Rx Hardware Channel Data.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Shared/Get Rx Hardware Channel Data.vi"/>
+				<Item Name="Get Static Channel Reference for Frame.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Shared/Get Static Channel Reference for Frame.vi"/>
+				<Item Name="Get String Text Bounds.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Get String Text Bounds.vi"/>
+				<Item Name="Get Text Rect.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/picture/picture.llb/Get Text Rect.vi"/>
+				<Item Name="Get Tx Hardware Channel Data.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Shared/Get Tx Hardware Channel Data.vi"/>
+				<Item Name="GetHelpDir.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/GetHelpDir.vi"/>
+				<Item Name="GetRTHostConnectedProp.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/GetRTHostConnectedProp.vi"/>
+				<Item Name="Implementation.lvlib" Type="Library" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Engine/Implementation/Implementation.lvlib"/>
+				<Item Name="Interfaces.lvlib" Type="Library" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Engine/Interfaces/Interfaces.lvlib"/>
+				<Item Name="Label Properties.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Shared/Label Properties.ctl"/>
+				<Item Name="Label.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Shared/Label.ctl"/>
+				<Item Name="Longest Line Length in Pixels.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Longest Line Length in Pixels.vi"/>
+				<Item Name="LV Config Read String.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/resource/dialog/lvconfig.llb/LV Config Read String.vi"/>
+				<Item Name="LVBoundsTypeDef.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/miscctls.llb/LVBoundsTypeDef.ctl"/>
+				<Item Name="LVDateTimeRec.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/miscctls.llb/LVDateTimeRec.ctl"/>
+				<Item Name="LVMapReplaceAction.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/miscctls.llb/LVMapReplaceAction.ctl"/>
+				<Item Name="LVRectTypeDef.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/miscctls.llb/LVRectTypeDef.ctl"/>
+				<Item Name="Messaging.lvlib" Type="Library" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI/VeriStand Custom Device Messaging/Messaging.lvlib"/>
+				<Item Name="NI_SystemLogging.lvlib" Type="Library" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/SystemLogging/NI_SystemLogging.lvlib"/>
+				<Item Name="nirviCommon.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/express/rvi/timingcommon/nirviCommon.vi"/>
+				<Item Name="Not Found Dialog.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Not Found Dialog.vi"/>
+				<Item Name="Parameter Definition.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Shared/Parameter Definition.ctl"/>
+				<Item Name="RT Hardware Channel Settings.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Shared/RT Hardware Channel Settings.ctl"/>
+				<Item Name="RT Label Settings.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Shared/RT Label Settings.ctl"/>
+				<Item Name="RT Parameters.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Shared/RT Parameters.ctl"/>
+				<Item Name="Search and Replace Pattern.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Search and Replace Pattern.vi"/>
+				<Item Name="Set Bold Text.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Set Bold Text.vi"/>
+				<Item Name="Set String Value.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Set String Value.vi"/>
+				<Item Name="Simple Error Handler.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Simple Error Handler.vi"/>
+				<Item Name="TagReturnType.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/TagReturnType.ctl"/>
+				<Item Name="Three Button Dialog CORE.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Three Button Dialog CORE.vi"/>
+				<Item Name="Three Button Dialog.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Three Button Dialog.vi"/>
+				<Item Name="Transfer Speed.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Shared/Transfer Speed.ctl"/>
+				<Item Name="Transfer Type.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Shared/Transfer Type.ctl"/>
+				<Item Name="Trim Whitespace.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Trim Whitespace.vi"/>
+				<Item Name="VS Inline Async API.lvlib" Type="Library" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI/NIVS Inline Async API/_VS Inline Async API/VS Inline Async API.lvlib"/>
+				<Item Name="whitespace.ctl" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/whitespace.ctl"/>
+			</Item>
 			<Item Name="NationalInstruments.VeriStand.SystemStorage" Type="Document" URL="NationalInstruments.VeriStand.SystemStorage">
 				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
 			</Item>
-			<Item Name="RT Driver VI.vi" Type="VI" URL="../../../Includes/AIM ARINC 429 Engine.lvlibp/Engine/Custom Device/RT Driver VI.vi"/>
+			<Item Name="NIVeriStand_DataServices.dll" Type="Document" URL="../../../Includes/NIVeriStand_DataServices.dll"/>
+			<Item Name="systemLogging.dll" Type="Document" URL="systemLogging.dll">
+				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
+			</Item>
 		</Item>
 		<Item Name="Build Specifications" Type="Build">
 			<Item Name="Engine Debug" Type="Source Distribution">
@@ -813,7 +874,6 @@
 				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
 				<Property Name="Bld_postActionVIID" Type="Ref">/My Computer/Utility/Copy .LLB to NI VeriStand dir.vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{E24CF77A-EDD5-435E-91DE-CAC6522BEA2A}</Property>
-				<Property Name="Bld_removeVIObj" Type="Int">1</Property>
 				<Property Name="Bld_targetDestDir" Type="Path">Linux_x64/AIM ARINC 429 Engine Linux64.llb</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">Destination Directory</Property>
@@ -824,7 +884,7 @@
 				<Property Name="Destination[1].path" Type="Path">/Linux_x64</Property>
 				<Property Name="Destination[1].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{BD9FE029-5AE5-4528-B32F-AA4B707B293D}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{9CA5E373-0187-4040-9EC2-32B64B9D957F}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/Linux x64/AIM ARINC 429 Engine.lvlib/RT Driver VI.vi</Property>

--- a/Source/Custom Device/AIM ARINC 429 Custom Device.lvproj
+++ b/Source/Custom Device/AIM ARINC 429 Custom Device.lvproj
@@ -891,7 +891,7 @@
 				<Property Name="Source[1].properties[0].type" Type="Str">Remove front panel</Property>
 				<Property Name="Source[1].properties[0].value" Type="Bool">false</Property>
 				<Property Name="Source[1].properties[1].type" Type="Str">Remove block diagram</Property>
-				<Property Name="Source[1].properties[1].value" Type="Bool">true</Property>
+				<Property Name="Source[1].properties[1].value" Type="Bool">false</Property>
 				<Property Name="Source[1].properties[2].type" Type="Str">Allow debugging</Property>
 				<Property Name="Source[1].properties[2].value" Type="Bool">false</Property>
 				<Property Name="Source[1].propertiesCount" Type="Int">3</Property>


### PR DESCRIPTION
This reverts commit 6f662f37987dbff6fef0e37460e75e20f283e9e0.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-aim-arinc429-custom-device/blob/main/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-aim-arinc429-custom-device/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Revert "fix: enabled some settings". Just keep add lv2025, remove lv2021, bump version. Disable remove block diagram

### Why should this Pull Request be merged?

Required for future release

### What testing has been done?

NA
